### PR TITLE
app-emulation/wine: Install shared libraries to $(get_libdir).

### DIFF
--- a/app-emulation/wine/wine-1.7.40.ebuild
+++ b/app-emulation/wine/wine-1.7.40.ebuild
@@ -323,13 +323,13 @@ pkg_setup() {
 	if use multislot; then
 		WINE_VARIANT="${PN#wine}-${PV}"
 		WINE_VARIANT="${WINE_VARIANT#-}"
-		MY_PREFIX=/usr/lib/wine-"${WINE_VARIANT}"
+		MY_PREFIX="${EROOT}"/usr/$(get_libdir)/wine-"${WINE_VARIANT}"
 		MY_DATADIR="${MY_PREFIX}"
 		MY_MANDIR="${MY_DATADIR}"/man
 	else
-		MY_PREFIX=/usr
-		MY_DATADIR=/usr/share
-		MY_MANDIR=/usr/share/man
+		MY_PREFIX="${EROOT}"/usr
+		MY_DATADIR="${EROOT}"/usr/share
+		MY_MANDIR="${EROOT}"/usr/share/man
 	fi
 
 	wine_build_environment_check || die


### PR DESCRIPTION
This pull request installs Wine shared libraries to multilib- and Gentoo Prefix-aware directories, fixing issue #1. Specifically, absolute paths defined by `pkg_setup()` are:
- Prefixed by `${EROOT}`, improving (strictly hypothetical) integration with [Gentoo Prefix](https://wiki.gentoo.org/wiki/Project:Prefix/Technical_Documentation#The_variables_ED_and_EROOT). `${EROOT}` was added by [EAPI 3](https://devmanual.gentoo.org/ebuild-writing/eapi) for this exact purpose, which was quite nice of them really.
- Substituted `/usr/lib` by `/usr/$(get_libdir)`, as required by the [`multilib-strict` Portage FEATURE](https://devmanual.gentoo.org/archs/amd64/index.html). Consider enabling `multilib-strict` locally, too. It's pretty sweet... until you hit things like this.

For simplicity, these changes apply _only_ to the **1.7.40** ebuild. While they could be manually backported to the other Wine ebuilds, I'd recommend a different tact. To avoid these sorts of [DRY issues](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) in the future, consider a new `wine.eclass` defining at least the following common phase functions: `pkg_pretend()`, `pkg_setup()`, `src_configure()`, `multilib_src_test()`, `pkg_preinst()`, `pkg_postinst()`, and `pkg_postrm()`. Those appear to be reduplicated in entirety between the various Wine ebuilds, and could probably benefit from refactoring out.

Thanks for the Sisyphean amount of hard work here, [NP-Hardass](https://github.com/NP-Hardass) and [eroen](https://github.com/eroen). It'd be awesome to see your efforts eventually wind up in Portage. But even if that never happens (...and let's be honest, this _is_ Gentoo), you've both done a legendary job.

**Your names shall be preserved into antiquity.**
